### PR TITLE
opam: dev-repo needs to end in .git

### DIFF
--- a/opam
+++ b/opam
@@ -3,7 +3,7 @@ name: "bisect_ppx"
 version: "0.1"
 maintainer: "Leonid Rozenberg <leonidr@gmail.com>"
 authors: "Leonid Rozenberg <leonidr@gmail.com>"
-dev-repo: "https://github.com/rleonid/bisect_ppx"
+dev-repo: "https://github.com/rleonid/bisect_ppx.git"
 bug-reports: "https://github.com/rleonid/bisect_ppx/issues"
 build: [
   ["sh" "configure"]


### PR DESCRIPTION
with a bare url, opam complains that this is not a recognised version-control URL.