### PR TITLE
Bugfix in CommentsLexer

### DIFF
--- a/src/syntax/commentsLexer.mll
+++ b/src/syntax/commentsLexer.mll
@@ -61,6 +61,8 @@ let report_unmatched_pair () =
 let eol = ('\010' | '\013' |"\013\010" | "\010\013")
 
 rule normal ignored marked stack = parse
+| "'\"'"                    { normal ignored marked stack lexbuf }
+| "'\\\"'"                  { normal ignored marked stack lexbuf }
 | "\""                      { string 0 ignored marked stack lexbuf }
 | "(*BISECT-IGNORE-BEGIN*)" { let line = get_line lexbuf in
                               Stack.push line stack;
@@ -84,10 +86,8 @@ rule normal ignored marked stack = parse
 | _                         { normal ignored marked stack lexbuf }
 
 and string n ignored marked stack = parse
-| "\\\""                    { if n = 0 then
-                                normal ignored marked stack lexbuf
-                              else
-                                comment n ignored marked stack lexbuf }
+| "\\\\"                    { string n ignored marked stack lexbuf }
+| "\\\""                    { string n ignored marked stack lexbuf }
 | "\""                      { if n = 0 then
                                 normal ignored marked stack lexbuf
                               else
@@ -102,6 +102,8 @@ and comment n ignored marked stack = parse
                                 normal ignored marked stack lexbuf
                               else
                                 comment (pred n) ignored marked stack lexbuf }
+| "'\"'"                    { comment n ignored marked stack lexbuf }
+| "'\\\"'"                  { comment n ignored marked stack lexbuf }
 | "\""                      { string n ignored marked stack lexbuf }
 | eol                       { incr_line lexbuf; comment n ignored marked stack lexbuf }
 | eof                       { fail lexbuf Unexpected_end_of_file }

--- a/tests/ppx-comments/source.ml
+++ b/tests/ppx-comments/source.ml
@@ -23,4 +23,8 @@ let f2 b x = (*BISECT-IGNORE*)
 (* Test the parsing of weird quote literals. *)
 let s1 = "\\\\"
 let s2 = '"'
+(* let s2 = '"' *)
 let s3 = '\"'
+(* let s3 = '\"' *)
+let s4 = "a\"a"
+

--- a/tests/ppx-comments/source.ml.reference
+++ b/tests/ppx-comments/source.ml.reference
@@ -12,3 +12,4 @@ let f2 b x = if b then x * x else x
 let s1 = Bisect.Runtime.mark "source.ml" 4; "\\\\"
 let s2 = Bisect.Runtime.mark "source.ml" 5; '"'
 let s3 = Bisect.Runtime.mark "source.ml" 6; '"'
+let s4 = Bisect.Runtime.mark "source.ml" 7; "a\"a"


### PR DESCRIPTION
It currently can't lex:

```
let x = "\\\\" (* Miss the end of string *)
let y = '"'    (* Mistaken as start of string *)
let z = \"'    (* Mistaken as start of string *)
```