### PR TITLE
Fixing bugs in the fast mode implementation.

### DIFF
--- a/META
+++ b/META
@@ -16,3 +16,10 @@ package "runtime" (
   archive(native,mt)="bisect.cmxa bisectThread.cmx"
   archive(java,mt)="bisect.cmja bisectThread.cmj"
 )
+
+package "fast" (
+  requires="bisect_ppx.runtime"
+  ppx="./bisect_ppx.byte"
+  ppxopt = "bisect_ppx.fast,-mode bisect_ppx.fast,fast"
+  description="The Bisect modules needed for instrumentation, running in fast mode."
+)

--- a/src/demo/Makefile
+++ b/src/demo/Makefile
@@ -5,6 +5,12 @@ build:
 build_with_source:
 	ocamlfind ocamlc -package bisect_ppx -linkpkg actors.ml test.ml -dsource -o test.covered
 
+fast:
+	ocamlfind ocamlc -w @44 -package bisect_ppx.fast -linkpkg actors.ml test.ml -o test.covered
+
+fast_with_source:
+	ocamlfind ocamlc -w @44 -package bisect_ppx.fast -linkpkg actors.ml test.ml -dsource -o test.covered
+
 run:
 	./test.covered
 

--- a/src/library/runtime.mli
+++ b/src/library/runtime.mli
@@ -33,15 +33,19 @@
     variable. The actual file name is the first non-existing
     "<base><n>.out" file where <base> is the base name and <n> a natural
     number value padded with zeroes to 4 digits (i.e. "0001", "0002", and
-    so on).
+    so on). This behavior is modified to be a random 4 digits, if
+    {!random_suffix} is set, as in thread mode to avoid race conditions.
 
     Another environment variable can be used to customize the behaviour of
     Bisect: "BISECT_SILENT". If this variable is set to "YES" or "ON"
     (ignoring case) then Bisect will not output any message (its default
-    value is "OFF"). If not silent, Bisect will output a message on the
-    standard error in various situations such as:
+    value is "OFF"). Otherwise Bisect will output a message in various
+    situations such as:
     - when the file cannot be created at program initialization;
     - when the data cannot be written at program termination.
+    If "BISECT_SILENT" is set to "ERR" (ignoring case) these error messages are
+    routed to stderr, otherwise "BISECT_SILENT" is used to determine a filename
+    for this output, defaults to "bisect.log".
 
     Because of the initialization part of Bisect, one is advised to link
     this module as one of the first ones of the program. Indeed, when

--- a/src/syntax/instrumentPpx.ml
+++ b/src/syntax/instrumentPpx.ml
@@ -400,6 +400,12 @@ class instrumenter = object (self)
               head :: rest
           | InstrumentArgs.Fast
           | InstrumentArgs.Faster ->
+              (* We have to add this here, before we process the rest of the
+                 structure, because that may also have structures contained
+                 there-in, but we'll add the header after processing all of
+                 those declarations so that we know how many instrumentations
+                 there are. *)
+              InstrumentState.add_file file;
               let rest = super#structure ast in
               let head = faster file in
               head :: rest

--- a/tests/ppx-instrument-fast/expr_binding.ml.reference
+++ b/tests/ppx-instrument-fast/expr_binding.ml.reference
@@ -1,23 +1,24 @@
-let ___bisect_mark___ =
-  let marks = Array.make 10 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_binding =
+  let marks = Array.make 10 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_binding.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
-let x = ( ___bisect_mark___ ) 0; 3
-let y = ( ___bisect_mark___ ) 1; [1; 2; 3]
-let z = ( ___bisect_mark___ ) 2; [|1;2;3|]
-let f x = ( ___bisect_mark___ ) 3; print_endline x
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
+let x = ___bisect_mark___expr_binding 0; 3
+let y = ___bisect_mark___expr_binding 1; [1; 2; 3]
+let z = ___bisect_mark___expr_binding 2; [|1;2;3|]
+let f x = ___bisect_mark___expr_binding 3; print_endline x
 let f' x =
-  ( ___bisect_mark___ ) 6;
-  (let x' = ( ___bisect_mark___ ) 4; String.uppercase x in
-   ( ___bisect_mark___ ) 5; print_endline x')
-let g x y z = ( ___bisect_mark___ ) 7; (x + y) * z
+  ___bisect_mark___expr_binding 6;
+  (let x' = ___bisect_mark___expr_binding 4; String.uppercase x in
+   ___bisect_mark___expr_binding 5; print_endline x')
+let g x y z = ___bisect_mark___expr_binding 7; (x + y) * z
 let g' x y =
-  (( ___bisect_mark___ ) 9; print_endline x);
-  ( ___bisect_mark___ ) 8;
+  (___bisect_mark___expr_binding 9; print_endline x);
+  ___bisect_mark___expr_binding 8;
   print_endline y

--- a/tests/ppx-instrument-fast/expr_class.ml.reference
+++ b/tests/ppx-instrument-fast/expr_class.ml.reference
@@ -1,37 +1,38 @@
-let ___bisect_mark___ =
-  let marks = Array.make 15 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_class =
+  let marks = Array.make 15 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_class.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
 class c =
-  object 
-    val mutable x = ( ___bisect_mark___ ) 0; 0
-    method get_x = ( ___bisect_mark___ ) 1; x
-    method set_x x' = ( ___bisect_mark___ ) 2; x <- x'
-    method print = ( ___bisect_mark___ ) 3; print_int x
-    initializer ( ___bisect_mark___ ) 4; print_endline "created"
+  object
+    val mutable x = ___bisect_mark___expr_class 0; 0
+    method get_x = ___bisect_mark___expr_class 1; x
+    method set_x x' = ___bisect_mark___expr_class 2; x <- x'
+    method print = ___bisect_mark___expr_class 3; print_int x
+    initializer ___bisect_mark___expr_class 4; print_endline "created"
   end
-let i = ( ___bisect_mark___ ) 5; new c
+let i = ___bisect_mark___expr_class 5; new c
 class c' =
-  object 
-    val mutable x = ( ___bisect_mark___ ) 6; 0
-    method get_x = ( ___bisect_mark___ ) 7; x
+  object
+    val mutable x = ___bisect_mark___expr_class 6; 0
+    method get_x = ___bisect_mark___expr_class 7; x
     method set_x x' =
-      (( ___bisect_mark___ ) 9; print_endline "modified");
-      ( ___bisect_mark___ ) 8;
+      (___bisect_mark___expr_class 9; print_endline "modified");
+      ___bisect_mark___expr_class 8;
       x <- x'
     method print =
-      (( ___bisect_mark___ ) 11; print_int x);
-      ( ___bisect_mark___ ) 10;
+      (___bisect_mark___expr_class 11; print_int x);
+      ___bisect_mark___expr_class 10;
       print_newline ()
     initializer
-      (( ___bisect_mark___ ) 13; print_string "created");
-      ( ___bisect_mark___ ) 12;
+      (___bisect_mark___expr_class 13; print_string "created");
+      ___bisect_mark___expr_class 12;
       print_newline ()
   end
-let i = ( ___bisect_mark___ ) 14; new c
+let i = ___bisect_mark___expr_class 14; new c

--- a/tests/ppx-instrument-fast/expr_for.ml.reference
+++ b/tests/ppx-instrument-fast/expr_for.ml.reference
@@ -1,27 +1,28 @@
-let ___bisect_mark___ =
-  let marks = Array.make 10 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_for =
+  let marks = Array.make 10 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_for.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
 let () =
-  (( ___bisect_mark___ ) 5; print_endline "before");
-  (( ___bisect_mark___ ) 4;
+  (___bisect_mark___expr_for 5; print_endline "before");
+  (___bisect_mark___expr_for 4;
    for i = 1 to 3 do
-     ((( ___bisect_mark___ ) 2; print_endline "abc");
-      (( ___bisect_mark___ ) 1; print_endline "def");
-      ( ___bisect_mark___ ) 0;
+     ((___bisect_mark___expr_for 2; print_endline "abc");
+      (___bisect_mark___expr_for 1; print_endline "def");
+      ___bisect_mark___expr_for 0;
       print_endline "ghi")
    done);
-  ( ___bisect_mark___ ) 3;
+  ___bisect_mark___expr_for 3;
   print_endline "after"
 let () =
-  (( ___bisect_mark___ ) 9; print_endline "before");
-  (( ___bisect_mark___ ) 8;
-   for i = 1 to 3 do (( ___bisect_mark___ ) 6; print_endline "abc") done);
-  ( ___bisect_mark___ ) 7;
+  (___bisect_mark___expr_for 9; print_endline "before");
+  (___bisect_mark___expr_for 8;
+   for i = 1 to 3 do (___bisect_mark___expr_for 6; print_endline "abc") done);
+  ___bisect_mark___expr_for 7;
   print_endline "after"

--- a/tests/ppx-instrument-fast/expr_ifthen.ml.reference
+++ b/tests/ppx-instrument-fast/expr_ifthen.ml.reference
@@ -1,26 +1,27 @@
-let ___bisect_mark___ =
-  let marks = Array.make 8 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_ifthen =
+  let marks = Array.make 8 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_ifthen.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
 let () =
-  ( ___bisect_mark___ ) 2;
+  ___bisect_mark___expr_ifthen 2;
   if true
-  then (( ___bisect_mark___ ) 1; print_endline "abc")
-  else (( ___bisect_mark___ ) 0; print_endline "def")
+  then (___bisect_mark___expr_ifthen 1; print_endline "abc")
+  else (___bisect_mark___expr_ifthen 0; print_endline "def")
 let () =
-  ( ___bisect_mark___ ) 7;
+  ___bisect_mark___expr_ifthen 7;
   if true
   then
-    ((( ___bisect_mark___ ) 6; print_string "abc");
-     ( ___bisect_mark___ ) 5;
+    ((___bisect_mark___expr_ifthen 6; print_string "abc");
+     ___bisect_mark___expr_ifthen 5;
      print_newline ())
   else
-    ((( ___bisect_mark___ ) 4; print_string "def");
-     ( ___bisect_mark___ ) 3;
+    ((___bisect_mark___expr_ifthen 4; print_string "def");
+     ___bisect_mark___expr_ifthen 3;
      print_newline ())

--- a/tests/ppx-instrument-fast/expr_lazyop.ml.reference
+++ b/tests/ppx-instrument-fast/expr_lazyop.ml.reference
@@ -1,14 +1,17 @@
-let ___bisect_mark___ =
-  let marks = Array.make 4 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_lazyop =
+  let marks = Array.make 4 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_lazyop.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
 let f x y =
-  (( ___bisect_mark___ ) 1; x > 0) && (( ___bisect_mark___ ) 0; y > 0)
+  (___bisect_mark___expr_lazyop 1; x > 0) &&
+    (___bisect_mark___expr_lazyop 0; y > 0)
 let g x y =
-  (( ___bisect_mark___ ) 3; x > 0) || (( ___bisect_mark___ ) 2; y > 0)
+  (___bisect_mark___expr_lazyop 3; x > 0) ||
+    (___bisect_mark___expr_lazyop 2; y > 0)

--- a/tests/ppx-instrument-fast/expr_match.ml.reference
+++ b/tests/ppx-instrument-fast/expr_match.ml.reference
@@ -1,50 +1,51 @@
-let ___bisect_mark___ =
-  let marks = Array.make 18 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_match =
+  let marks = Array.make 18 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_match.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
 let () =
   match x with
-  | 0 -> (( ___bisect_mark___ ) 0; print_endline "abc")
-  | 1 -> (( ___bisect_mark___ ) 1; print_endline "def")
-  | _ -> (( ___bisect_mark___ ) 2; print_endline "ghi")
+  | 0 -> (___bisect_mark___expr_match 0; print_endline "abc")
+  | 1 -> (___bisect_mark___expr_match 1; print_endline "def")
+  | _ -> (___bisect_mark___expr_match 2; print_endline "ghi")
 let f =
   function
-  | 0 -> (( ___bisect_mark___ ) 3; print_endline "abc")
-  | 1 -> (( ___bisect_mark___ ) 4; print_endline "def")
-  | _ -> (( ___bisect_mark___ ) 5; print_endline "ghi")
+  | 0 -> (___bisect_mark___expr_match 3; print_endline "abc")
+  | 1 -> (___bisect_mark___expr_match 4; print_endline "def")
+  | _ -> (___bisect_mark___expr_match 5; print_endline "ghi")
 let () =
   match x with
   | 0 ->
-      ((( ___bisect_mark___ ) 7; print_string "abc");
-       ( ___bisect_mark___ ) 6;
+      ((___bisect_mark___expr_match 7; print_string "abc");
+       ___bisect_mark___expr_match 6;
        print_newline ())
   | 1 ->
-      ((( ___bisect_mark___ ) 9; print_string "def");
-       ( ___bisect_mark___ ) 8;
+      ((___bisect_mark___expr_match 9; print_string "def");
+       ___bisect_mark___expr_match 8;
        print_newline ())
   | _ ->
-      ((( ___bisect_mark___ ) 11; print_string "ghi");
-       ( ___bisect_mark___ ) 10;
+      ((___bisect_mark___expr_match 11; print_string "ghi");
+       ___bisect_mark___expr_match 10;
        print_newline ())
 let f =
   function
   | 0 ->
-      ((( ___bisect_mark___ ) 13; print_string "abc");
-       ( ___bisect_mark___ ) 12;
+      ((___bisect_mark___expr_match 13; print_string "abc");
+       ___bisect_mark___expr_match 12;
        print_newline ())
   | 1 ->
-      ((( ___bisect_mark___ ) 15; print_string "def");
-       ( ___bisect_mark___ ) 14;
+      ((___bisect_mark___expr_match 15; print_string "def");
+       ___bisect_mark___expr_match 14;
        print_newline ())
   | _ ->
-      ((( ___bisect_mark___ ) 17; print_string "ghi");
-       ( ___bisect_mark___ ) 16;
+      ((___bisect_mark___expr_match 17; print_string "ghi");
+       ___bisect_mark___expr_match 16;
        print_newline ())
 File "expr_match.ml", line 2, characters 8-9:
 Error: Unbound value x

--- a/tests/ppx-instrument-fast/expr_polyrec.ml.reference
+++ b/tests/ppx-instrument-fast/expr_polyrec.ml.reference
@@ -1,17 +1,25 @@
-let ___bisect_mark___ =
-  let marks = Array.make 6 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_polyrec =
+  let marks = Array.make 7 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_polyrec.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
-let rec f : 'a . 'a -> unit =
-  fun _ -> (( ___bisect_mark___ ) 1; f 0); ( ___bisect_mark___ ) 0; f ""
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
+let rec f : 'a . 'a -> unit=
+  fun _  ->
+    (___bisect_mark___expr_polyrec 1; f 0);
+    ___bisect_mark___expr_polyrec 0;
+    f ""
 let () =
-  ( ___bisect_mark___ ) 5;
-  (let rec f : 'a . 'a -> unit =
-     fun _ -> (( ___bisect_mark___ ) 3; f 0); ( ___bisect_mark___ ) 2; f "" in
-   ( ___bisect_mark___ ) 4; f 0)
+  ___bisect_mark___expr_polyrec 6;
+  (let rec f : 'a . 'a -> unit=
+     ___bisect_mark___expr_polyrec 4;
+     (fun _  ->
+        (___bisect_mark___expr_polyrec 3; f 0);
+        ___bisect_mark___expr_polyrec 2;
+        f "") in
+   ___bisect_mark___expr_polyrec 5; f 0)

--- a/tests/ppx-instrument-fast/expr_sequence.ml.reference
+++ b/tests/ppx-instrument-fast/expr_sequence.ml.reference
@@ -1,20 +1,21 @@
-let ___bisect_mark___ =
-  let marks = Array.make 6 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_sequence =
+  let marks = Array.make 6 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_sequence.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
-let () = ( ___bisect_mark___ ) 0; print_endline "abc"
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
+let () = ___bisect_mark___expr_sequence 0; print_endline "abc"
 let () =
-  (( ___bisect_mark___ ) 2; print_endline "abc");
-  ( ___bisect_mark___ ) 1;
+  (___bisect_mark___expr_sequence 2; print_endline "abc");
+  ___bisect_mark___expr_sequence 1;
   print_endline "def"
 let () =
-  (( ___bisect_mark___ ) 5; print_endline "abc");
-  (( ___bisect_mark___ ) 4; print_endline "def");
-  ( ___bisect_mark___ ) 3;
+  (___bisect_mark___expr_sequence 5; print_endline "abc");
+  (___bisect_mark___expr_sequence 4; print_endline "def");
+  ___bisect_mark___expr_sequence 3;
   print_endline "ghi"

--- a/tests/ppx-instrument-fast/expr_try.ml.reference
+++ b/tests/ppx-instrument-fast/expr_try.ml.reference
@@ -1,31 +1,32 @@
-let ___bisect_mark___ =
-  let marks = Array.make 12 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_try =
+  let marks = Array.make 12 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_try.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
 let () =
-  (( ___bisect_mark___ ) 6; print_endline "before");
-  (( ___bisect_mark___ ) 5;
+  (___bisect_mark___expr_try 6; print_endline "before");
+  (___bisect_mark___expr_try 5;
    (try
-      (( ___bisect_mark___ ) 3; print_endline "abc");
-      ( ___bisect_mark___ ) 2;
+      (___bisect_mark___expr_try 3; print_endline "abc");
+      ___bisect_mark___expr_try 2;
       print_endline "def"
     with
     | _ ->
-        ((( ___bisect_mark___ ) 1; print_endline "ABC");
-         ( ___bisect_mark___ ) 0;
+        ((___bisect_mark___expr_try 1; print_endline "ABC");
+         ___bisect_mark___expr_try 0;
          print_endline "DEF")));
-  ( ___bisect_mark___ ) 4;
+  ___bisect_mark___expr_try 4;
   print_endline "after"
 let () =
-  (( ___bisect_mark___ ) 11; print_endline "before");
-  (( ___bisect_mark___ ) 10;
-   (try ( ___bisect_mark___ ) 8; print_endline "abc"
-    with | _ -> (( ___bisect_mark___ ) 7; print_endline "ABC")));
-  ( ___bisect_mark___ ) 9;
+  (___bisect_mark___expr_try 11; print_endline "before");
+  (___bisect_mark___expr_try 10;
+   (try ___bisect_mark___expr_try 8; print_endline "abc"
+    with | _ -> (___bisect_mark___expr_try 7; print_endline "ABC")));
+  ___bisect_mark___expr_try 9;
   print_endline "after"

--- a/tests/ppx-instrument-fast/expr_while.ml.reference
+++ b/tests/ppx-instrument-fast/expr_while.ml.reference
@@ -1,27 +1,28 @@
-let ___bisect_mark___ =
-  let marks = Array.make 10 0 and (hook_before,hook_after) =
-    Bisect.Runtime.get_hooks () in
+let ___bisect_mark___expr_while =
+  let marks = Array.make 10 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_while.ml" marks true;
-  (fun idx ->
-     (hook_before ();
-      (let curr = marks.(idx) in
-       marks.(idx) <-
-       if curr < Pervasives.max_int then Pervasives.succ curr else curr));
-     hook_after ())
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
 let () =
-  (( ___bisect_mark___ ) 5; print_endline "before");
-  (( ___bisect_mark___ ) 4;
+  (___bisect_mark___expr_while 5; print_endline "before");
+  (___bisect_mark___expr_while 4;
    while true do
-     ((( ___bisect_mark___ ) 2; print_endline "abc");
-      (( ___bisect_mark___ ) 1; print_endline "def");
-      ( ___bisect_mark___ ) 0;
+     ((___bisect_mark___expr_while 2; print_endline "abc");
+      (___bisect_mark___expr_while 1; print_endline "def");
+      ___bisect_mark___expr_while 0;
       print_endline "ghi")
      done);
-  ( ___bisect_mark___ ) 3;
+  ___bisect_mark___expr_while 3;
   print_endline "after"
 let () =
-  (( ___bisect_mark___ ) 9; print_endline "before");
-  (( ___bisect_mark___ ) 8;
-   while true do (( ___bisect_mark___ ) 6; print_endline "abc") done);
-  ( ___bisect_mark___ ) 7;
+  (___bisect_mark___expr_while 9; print_endline "before");
+  (___bisect_mark___expr_while 8;
+   while true do (___bisect_mark___expr_while 6; print_endline "abc") done);
+  ___bisect_mark___expr_while 7;
   print_endline "after"

--- a/tests/ppx-instrument-fast/nested_module.ml
+++ b/tests/ppx-instrument-fast/nested_module.ml
@@ -1,0 +1,7 @@
+let x = 3
+
+module F = struct
+  let y x = x + 4
+end
+
+let z x = x + 5

--- a/tests/ppx-instrument-fast/nested_module.ml.reference
+++ b/tests/ppx-instrument-fast/nested_module.ml.reference
@@ -1,0 +1,14 @@
+let ___bisect_mark___192291330 =
+  let marks = Array.make 3 0
+  and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
+  Bisect.Runtime.init_with_array "nested_module.ml" marks true;
+  (function
+   | idx ->
+       ((hook_before ();
+         (let curr = marks.(idx) in
+          marks.(idx) <-
+          if curr < Pervasives.max_int then Pervasives.succ curr else curr));
+        hook_after ()))
+let x = ___bisect_mark___192291330 0; 3
+module F = struct let y x = ___bisect_mark___192291330 1; x + 4 end
+let z x = ___bisect_mark___192291330 2; x + 5

--- a/tests/ppx-instrument-fast/nested_module.ml.reference
+++ b/tests/ppx-instrument-fast/nested_module.ml.reference
@@ -1,4 +1,4 @@
-let ___bisect_mark___192291330 =
+let ___bisect_mark___nested_module =
   let marks = Array.make 3 0
   and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "nested_module.ml" marks true;
@@ -9,6 +9,6 @@ let ___bisect_mark___192291330 =
           marks.(idx) <-
           if curr < Pervasives.max_int then Pervasives.succ curr else curr));
         hook_after ()))
-let x = ___bisect_mark___192291330 0; 3
-module F = struct let y x = ___bisect_mark___192291330 1; x + 4 end
-let z x = ___bisect_mark___192291330 2; x + 5
+let x = ___bisect_mark___nested_module 0; 3
+module F = struct let y x = ___bisect_mark___nested_module 1; x + 4 end
+let z x = ___bisect_mark___nested_module 2; x + 5

--- a/tests/ppx-instrument/nested_module.ml
+++ b/tests/ppx-instrument/nested_module.ml
@@ -1,0 +1,7 @@
+let x = 3
+
+module F = struct
+  let y x = x + 4
+end
+
+let z x = x + 5

--- a/tests/ppx-instrument/nested_module.ml.reference
+++ b/tests/ppx-instrument/nested_module.ml.reference
@@ -1,0 +1,5 @@
+let _ = Bisect.Runtime.init "nested_module.ml"
+let x = Bisect.Runtime.mark "nested_module.ml" 0; 3
+module F =
+  struct let y x = Bisect.Runtime.mark "nested_module.ml" 1; x + 4 end
+let z x = Bisect.Runtime.mark "nested_module.ml" 2; x + 5


### PR DESCRIPTION
- Allocate a fixed size array at the beginning of the module,
  where counters are incremented during code execution.
- Updated the demo with fast targets.
- Update META to include a new package: bisect_ppx.fast.
- Changes to the test suite to accomodate changes.

This would fix #3 