### PR TITLE
Parse OCaml line directives for BISECT comments

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 0.2.5
 -------------
   - Revert the _Random_ indices for output files, just create multiple
   - Correct dependency on Str in META.
+  - Obey OCamls line directive when looking for BISECT comments.
 
 Version 0.2.4 (2015-08-14):
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -99,3 +99,15 @@ A list of changes from the original `Bisect` implementation.
   behavior set `BISECT_SILENT=ERR`. You can use the same variable to set
   a filename; `"YES"` or `"ON"` will still turn off runtime logging
   altogether. 
+- Comments now obey OCaml line directives.
+
+  OCaml source code has [line directives](http://caml.inria.fr/pub/docs/manual-ocaml/lex.html#linenum-directive) (ex: `# 1 "foo.ml"`) that change the
+  position, and more importantly for our case, filenames that are being
+  lexed. `bisect_ppx` now keeps tracks of these changes only for the purposes
+  of **BISECT comments** (ex: `(*BISECT-IGNORE-BEGIN*)`).
+  
+  The overall instrumentation for code-coverage purposes ignores them as all of
+  the code of one post-preprocessed file is considered a part of the same OCaml
+  module [structure](http://caml.inria.fr/pub/docs/manual-ocaml/moduleexamples.html#sec18).
+  Code instrumented after a filename change, will still be reported as in the
+  original filename.

--- a/src/syntax/instrumentPpx.ml
+++ b/src/syntax/instrumentPpx.ml
@@ -112,19 +112,22 @@ let wrap_expr k e =
     e
   else
     let ofs = loc.Location.loc_start.Lexing.pos_cnum in
-    let file = !Location.input_name in
+    (* Different files because of the line directive *)
+    let file = loc.Location.loc_start.Lexing.pos_fname in
     let line = loc.Location.loc_start.Lexing.pos_lnum in
     let c = CommentsPpx.get file in
     let ignored =
       List.exists
         (fun (lo, hi) ->
           line >= lo && line <= hi)
-        c.CommentsPpx.ignored_intervals in
+        c.CommentsPpx.ignored_intervals
+    in
     if ignored then
       e
     else
       let marked = List.mem line c.CommentsPpx.marked_lines in
-      match marker file ofs k marked with
+      let marker_file = !Location.input_name in
+      match marker marker_file ofs k marked with
       | Some w -> Exp.sequence ~loc w e
       | None   -> e
 

--- a/tests/line-number-directive/Makefile
+++ b/tests/line-number-directive/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
+		diff -q $$file.reference $$file.result || (diff $$file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/line-number-directive/Makefile
+++ b/tests/line-number-directive/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || exit 1; \
+		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/line-number-directive/Makefile
+++ b/tests/line-number-directive/Makefile
@@ -1,0 +1,8 @@
+default:
+	@rm -fr *.result *.cm*
+	@for file in *.ml; do \
+		echo "     testing '$$file' ..."; \
+		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte' -dsource $$file 2> $$file.result; \
+		diff -q $$file.reference $$file.result || exit 1; \
+	done
+	@rm -fr *.result *.cm*

--- a/tests/line-number-directive/expr_binding.ml
+++ b/tests/line-number-directive/expr_binding.ml
@@ -1,0 +1,19 @@
+let x = 3
+
+let y = [1; 2; 3]
+
+let z = [|1; 2; 3|]
+
+let f x = print_endline x
+
+# 1 "not_expr_binding.ml"
+
+let f' x =
+  let x' = String.uppercase x in
+  print_endline x'
+
+let g x y z = (x + y) * z
+
+let g' x y =
+  print_endline x;
+  print_endline y

--- a/tests/line-number-directive/expr_binding.ml.reference
+++ b/tests/line-number-directive/expr_binding.ml.reference
@@ -1,0 +1,14 @@
+let _ = Bisect.Runtime.init "expr_binding.ml"
+let x = Bisect.Runtime.mark "expr_binding.ml" 0; 3
+let y = Bisect.Runtime.mark "expr_binding.ml" 1; [1; 2; 3]
+let z = Bisect.Runtime.mark "expr_binding.ml" 2; [|1;2;3|]
+let f x = Bisect.Runtime.mark "expr_binding.ml" 3; print_endline x
+let f' x =
+  Bisect.Runtime.mark "expr_binding.ml" 6;
+  (let x' = Bisect.Runtime.mark "expr_binding.ml" 4; String.uppercase x in
+   Bisect.Runtime.mark "expr_binding.ml" 5; print_endline x')
+let g x y z = Bisect.Runtime.mark "expr_binding.ml" 7; (x + y) * z
+let g' x y =
+  (Bisect.Runtime.mark "expr_binding.ml" 9; print_endline x);
+  Bisect.Runtime.mark "expr_binding.ml" 8;
+  print_endline y

--- a/tests/line-number-directive/expr_comment.ml
+++ b/tests/line-number-directive/expr_comment.ml
@@ -1,0 +1,20 @@
+let x = 3
+
+let y = [1; 2; 3]
+
+let z = [|1; 2; 3|]
+
+# 1 "not_expr_binding.ml"
+(*BISECT-IGNORE-BEGIN*)
+let f x = print_endline x
+
+let f' x =
+  let x' = String.uppercase x in
+  print_endline x'
+
+let g x y z = (x + y) * z
+
+let g' x y =
+  print_endline x;
+  print_endline y
+(*BISECT-IGNORE-END*)

--- a/tests/line-number-directive/expr_comment.ml.reference
+++ b/tests/line-number-directive/expr_comment.ml.reference
@@ -1,0 +1,8 @@
+let _ = Bisect.Runtime.init "expr_comment.ml"
+let x = Bisect.Runtime.mark "expr_comment.ml" 0; 3
+let y = Bisect.Runtime.mark "expr_comment.ml" 1; [1; 2; 3]
+let z = Bisect.Runtime.mark "expr_comment.ml" 2; [|1;2;3|]
+let f x = print_endline x
+let f' x = let x' = String.uppercase x in print_endline x'
+let g x y z = (x + y) * z
+let g' x y = print_endline x; print_endline y

--- a/tests/ppx-comments/Makefile
+++ b/tests/ppx-comments/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
+		diff -q $$file.reference $$file.result || (diff $$file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-comments/Makefile
+++ b/tests/ppx-comments/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || exit 1; \
+		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-deriving/Makefile
+++ b/tests/ppx-deriving/Makefile
@@ -2,9 +2,9 @@ PATH_OCAML_BIN=/Users/leonidrozenberg/.opam/4.02.1/bin/
 
 default: clean
 	@sh m1_blob.sh 2> blob1.result; \
-	diff -q blob1.reference blob1.result || exit 1; \
+	diff -q blob1.reference blob1.result || (diff blob1.reference blob1.result && exit 1); \
 	sh m2_blob.sh 2> blob2.result; \
-	diff -q blob2.reference blob2.result || exit 1; \
+	diff -q blob2.reference blob2.result || (diff blob2.reference blob2.result && exit 1); \
 	sh m2_deriving.sh 2> deriving2.result; \
 	diff -q deriving2.reference deriving2.result || exit 1; \
 

--- a/tests/ppx-exclude-file/Makefile
+++ b/tests/ppx-exclude-file/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte -exclude-file exclusions' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
+		diff -q $$file.reference $$file.result || (diff $$file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-exclude-file/Makefile
+++ b/tests/ppx-exclude-file/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte -exclude-file exclusions' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || exit 1; \
+		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-exclude/Makefile
+++ b/tests/ppx-exclude/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx "../../_build/src/syntax/bisect_ppx.byte -exclude 'f.*'" -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
+		diff -q $$file.reference $$file.result || (diff $$file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-exclude/Makefile
+++ b/tests/ppx-exclude/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx "../../_build/src/syntax/bisect_ppx.byte -exclude 'f.*'" -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || exit 1; \
+		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-instrument-fast/Makefile
+++ b/tests/ppx-instrument-fast/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte -mode fast' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || exit 1; \
+		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-instrument-fast/Makefile
+++ b/tests/ppx-instrument-fast/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte -mode fast' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
+		diff -q $$file.reference $$file.result || (diff $$file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-instrument/Makefile
+++ b/tests/ppx-instrument/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
+		diff -q $$file.reference $$file.result || (diff $$file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tests/ppx-instrument/Makefile
+++ b/tests/ppx-instrument/Makefile
@@ -3,6 +3,6 @@ default:
 	@for file in *.ml; do \
 		echo "     testing '$$file' ..."; \
 		$(PATH_OCAML_BIN)/ocamlc -c -I ../../_build -ppx '../../_build/src/syntax/bisect_ppx.byte' -dsource $$file 2> $$file.result; \
-		diff -q $$file.reference $$file.result || exit 1; \
+		diff -q $$file.reference $$file.result || (diff $file.reference $$file.result && exit 1); \
 	done
 	@rm -fr *.result *.cm*

--- a/tools/travis_ci_test.sh
+++ b/tools/travis_ci_test.sh
@@ -59,6 +59,7 @@ sh configure
 echo Compiling
 make all
 
+opam install ppx_blob ounit # used in test suite.
 echo Testing
 make tests
 


### PR DESCRIPTION
OCaml source code has line directives (# 1 "foo.ml") that change the
position, and more importantly for our case, filenames that are being
lexed. We would like to keep track of that information for correctly
implementing comments. The overall instrumentation though, is _still_
the top level filename because that strucutre is passed to the PPX
rewriter.