### PR TITLE
Add points on function expressions.

### DIFF
--- a/src/syntax/instrumentPpx.ml
+++ b/src/syntax/instrumentPpx.ml
@@ -325,6 +325,9 @@ class instrumenter = object (self)
       | Pexp_match (e, l) ->
           List.map (wrap_case Common.Match) l
           |> Exp.match_ ~loc e
+      | Pexp_function l ->
+          List.map (wrap_case Common.Match) l
+          |> Exp.function_ ~loc
       | Pexp_try (e, l) ->
           List.map (wrap_case Common.Try) l
           |> Exp.try_ ~loc (wrap_expr Common.Sequence e)

--- a/tests/ppx-instrument/expr_match.ml
+++ b/tests/ppx-instrument/expr_match.ml
@@ -32,3 +32,11 @@ let f x =
 let f = function
   | Foo -> print_string "foo"; print_newline ()
   | Bar -> print_string "bar"; print_newline ()
+
+let f x =
+  (function
+  | Foo -> "foo"
+  | Bar -> "bar")
+  x
+  |> print_string;
+  print_newline ()

--- a/tests/ppx-instrument/expr_match.ml.reference
+++ b/tests/ppx-instrument/expr_match.ml.reference
@@ -60,3 +60,11 @@ let f =
       ((Bisect.Runtime.mark "expr_match.ml" 25; print_string "bar");
        Bisect.Runtime.mark "expr_match.ml" 24;
        print_newline ())
+let f x =
+  (Bisect.Runtime.mark "expr_match.ml" 29;
+   ((function
+     | Foo  -> (Bisect.Runtime.mark "expr_match.ml" 26; "foo")
+     | Bar  -> (Bisect.Runtime.mark "expr_match.ml" 27; "bar")) x) |>
+     print_string);
+  Bisect.Runtime.mark "expr_match.ml" 28;
+  print_newline ()


### PR DESCRIPTION
In addition, I would suggest that the other tests in `expr_match.ml` be rewritten to avoid sequence expressions in cases. It seems that points are added on sequence expressions, and these mask potential problems with points being added to match cases.