### PR TITLE
Add points on nested and anonymous functions.

### DIFF
--- a/src/syntax/instrumentPpx.ml
+++ b/src/syntax/instrumentPpx.ml
@@ -313,6 +313,9 @@ class instrumenter = object (self)
             List.map (fun vb ->
             {vb with pvb_expr = wrap_expr Common.Binding vb.pvb_expr}) l in
           Exp.let_ ~loc rec_flag l (wrap_expr Common.Binding e)
+      | Pexp_fun (al, eo, p, e) ->
+          let eo = map_opt (wrap_expr Common.Binding) eo in
+          Exp.fun_ ~loc al eo p (wrap_func Common.Binding e)
       | Pexp_apply (e1, [l2, e2; l3, e3]) ->
           (match e1.pexp_desc with
           | Pexp_ident ident

--- a/tests/ppx-instrument-fast/expr_binding.ml
+++ b/tests/ppx-instrument-fast/expr_binding.ml
@@ -15,3 +15,8 @@ let g x y z = (x + y) * z
 let g' x y =
   print_endline x;
   print_endline y
+
+let () =
+  let f _ = 0 in
+  let _g _ = 1 in
+  print_endline (string_of_int (f ()))

--- a/tests/ppx-instrument-fast/expr_binding.ml.reference
+++ b/tests/ppx-instrument-fast/expr_binding.ml.reference
@@ -1,5 +1,5 @@
 let ___bisect_mark___expr_binding =
-  let marks = Array.make 10 0
+  let marks = Array.make 15 0
   and (hook_before,hook_after) = Bisect.Runtime.get_hooks () in
   Bisect.Runtime.init_with_array "expr_binding.ml" marks true;
   (function
@@ -22,3 +22,9 @@ let g' x y =
   (___bisect_mark___expr_binding 9; print_endline x);
   ___bisect_mark___expr_binding 8;
   print_endline y
+let () =
+  ___bisect_mark___expr_binding 14;
+  (let f _ = ___bisect_mark___expr_binding 12; 0 in
+   ___bisect_mark___expr_binding 13;
+   (let _g _ = ___bisect_mark___expr_binding 10; 1 in
+    ___bisect_mark___expr_binding 11; print_endline (string_of_int (f ()))))

--- a/tests/ppx-instrument/expr_binding.ml
+++ b/tests/ppx-instrument/expr_binding.ml
@@ -15,3 +15,8 @@ let g x y z = (x + y) * z
 let g' x y =
   print_endline x;
   print_endline y
+
+let () =
+  let f _ = 0 in
+  let _g _ = 1 in
+  print_endline (string_of_int (f ()))

--- a/tests/ppx-instrument/expr_binding.ml.reference
+++ b/tests/ppx-instrument/expr_binding.ml.reference
@@ -12,3 +12,10 @@ let g' x y =
   (Bisect.Runtime.mark "expr_binding.ml" 9; print_endline x);
   Bisect.Runtime.mark "expr_binding.ml" 8;
   print_endline y
+let () =
+  Bisect.Runtime.mark "expr_binding.ml" 14;
+  (let f _ = Bisect.Runtime.mark "expr_binding.ml" 12; 0 in
+   Bisect.Runtime.mark "expr_binding.ml" 13;
+   (let _g _ = Bisect.Runtime.mark "expr_binding.ml" 10; 1 in
+    Bisect.Runtime.mark "expr_binding.ml" 11;
+    print_endline (string_of_int (f ()))))


### PR DESCRIPTION
This commit adds points on nested and anonymous functions, but I have some reservations. I didn't write test cases because I want to discuss first, but my test program was:

```
let () =
  let f x = 0 in
  let g x = 1 in   (* I would like to know that this isn't called. *)

  f () |> string_of_int |> print_endline
```

Without this commit, points are not generated before `0` and `1`, and the coverage report does not indicate that `g` is not tested (or that `f` *is* tested, for that matter).

Concerns are:

- There is a separate function `wrap_func`, for wrapping `Pexp_fun`s that occur at the top level of a structure item binding or in a class. It seems the intent of the original code was only to generate points at the top level. Is there a reason for this?
- There isn't even a point kind for nested or anonymous functions (I used `Binding` for now). Again, it seems I am doing something in this commit that wasn't intended.

This change increased the number of points generated for my project by about 25% and slowed down testing just a bit.