### PR TITLE
Add simple performance test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,27 +19,34 @@
 CFLAGS := -cflags -w,+A-4-48
 OCAMLBUILD_FLAGS := -use-ocamlfind -no-links $(CFLAGS)
 
-RUN := ocamlbuild $(OCAMLBUILD_FLAGS) test_main.native -- -runner sequential
+UNIT := ocamlbuild $(OCAMLBUILD_FLAGS) test_main.native -- -runner sequential
+PERFORMANCE := \
+	ocamlbuild $(OCAMLBUILD_FLAGS) performance/test_performance.native -- \
+		-runner sequential -display false
 
 default: FORCE
 	@echo 'Available targets:'
-	@echo '  all              runs all tests'
-	@echo '  one NAME=name    runs the test whose name is passed'
-	@echo '  list             list available tests'
-	@echo '  log              show log for last execution'
+	@echo '  all              runs all unit tests'
+	@echo '  one NAME=name    runs the unit test whose name is passed'
+	@echo '  list             list available unit tests'
+	@echo '  log              show log for last unit test execution'
+	@echo '  performance      runs the performance tests'
 	@echo '  clean            deletes build and log files'
 
 all: FORCE
-	$(RUN)
+	$(UNIT)
 
 one: FORCE
-	$(RUN) -only-test $(NAME)
+	$(UNIT) -only-test $(NAME)
 
 list: FORCE
-	$(RUN) -list-test
+	$(UNIT) -list-test
 
 log: FORCE
 	less -N _build/oUnit-bisect_ppx*.log
+
+performance: FORCE
+	$(PERFORMANCE)
 
 clean: FORCE
 	ocamlbuild -clean

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,8 @@
 Running tests
 -------------
 
-To run all tests, run `make tests` in the project directory, or `make all` in
-subdirectory `tests/`.
+To run all unit tests, run `make tests` in the project directory, or `make all`
+in subdirectory `tests/`.
 
 If a test fails, you will see an error message describing the problem. If you
 want to re-run only that test, you can do `make one NAME=test_name` in `tests/`.
@@ -32,6 +32,8 @@ make tests STRICT_DEPENDENCIES=yes
 
 If an external command run by a test fails, its output ends up woven in before
 the error message, for the time being.
+
+To run the performance test, run `make performance` in `tests/`.
 
 Writing tests
 -------------

--- a/tests/performance/source.ml
+++ b/tests/performance/source.ml
@@ -1,0 +1,7 @@
+let () =
+  let rec repeat n =
+    if n <= 0 then ()
+    else repeat (n - 1)
+  in
+
+  Sys.argv.(1) |> int_of_string |> repeat

--- a/tests/performance/test_performance.ml
+++ b/tests/performance/test_performance.ml
@@ -1,0 +1,53 @@
+(*
+ * This file is part of Bisect_ppx.
+ * Copyright (C) 2016 Anton Bachin.
+ *
+ * Bisect is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *)
+
+open OUnit2
+open Test_helpers
+
+let count = 1000000
+let command = Printf.sprintf "time ./a.out %i" count
+
+let test ?(uninstrumented = false) ?(cflags = "") ?(bisect = "") name =
+  name >:: fun context ->
+    let cflags =
+      if uninstrumented then cflags
+      else (with_bisect_ppx_args bisect) ^ " " ^ cflags
+    in
+
+    with_directory context begin fun () ->
+      compile cflags "performance/source.ml";
+      print_endline ("\n " ^ name);
+      run command
+    end
+
+let with_threads =
+  "-thread -linkall " ^
+  "unix.cma threads.cma ../../_build/src/threads/bisectThread.cmo"
+
+let tests = "performance" >::: [
+  test "uninstrumented" ~uninstrumented:true;
+  test "safe"           ~bisect:"-mode safe";
+  test "safe-threads"   ~bisect:"-mode safe" ~cflags:with_threads;
+  test "fast"           ~bisect:"-mode fast";
+  test "fast-threads"   ~bisect:"-mode safe" ~cflags:with_threads;
+  test "faster"         ~bisect:"-mode faster";
+  test "faster-threads" ~bisect:"-mode faster" ~cflags:with_threads
+]
+
+let () =
+  run_test_tt_main tests

--- a/tools/travis_ci_test.sh
+++ b/tools/travis_ci_test.sh
@@ -67,3 +67,4 @@ echo
 echo "Testing"
 echo
 make tests STRICT_DEPENDENCIES=yes
+( cd tests && make performance )


### PR DESCRIPTION
The test builds a small program instrumented in various modes and compares the resulting running times against each other and against an uninstrumented binary.

This currently uses the `time` command/shell built-in, so output may look different on each system. Might want to switch to something else later.

Resolves #45.

This was almost trivial to write with the new testing setup.