### PR TITLE
Add thread safety test

### DIFF
--- a/tests/test_main.ml
+++ b/tests/test_main.ml
@@ -29,6 +29,7 @@ let tests = "bisect_ppx" >::: [
   Test_exclude.tests;
   Test_exclude_file.tests;
   Test_ppx_integration.tests;
+  Test_thread_safety.tests;
   Test_ounit_integration.tests
 ]
 

--- a/tests/thread-safety/reference
+++ b/tests/thread-safety/reference
@@ -1,0 +1,1 @@
+    <point offset="44" count="2000000" kind="for"/>

--- a/tests/thread-safety/source.ml
+++ b/tests/thread-safety/source.ml
@@ -1,0 +1,10 @@
+let () =
+  let repeat n = for i = 1 to n do () done in
+
+  let count = Sys.argv.(1) |> int_of_string in
+
+  let thread_1 = Thread.create repeat count in
+  let thread_2 = Thread.create repeat count in
+
+  Thread.join thread_1;
+  Thread.join thread_2

--- a/tests/thread-safety/test_thread_safety.ml
+++ b/tests/thread-safety/test_thread_safety.ml
@@ -1,0 +1,60 @@
+(*
+ * This file is part of Bisect_ppx.
+ * Copyright (C) 2016 Anton Bachin.
+ *
+ * Bisect is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *)
+
+(* Note that the reference file may have to be adjusted if point instrumentation
+   code is changed. *)
+
+open OUnit2
+open Test_helpers
+
+let count = 1000000
+let command = Printf.sprintf "./a.out %i" count
+
+let test ?(with_threads = false) ?(bisect = "") name expect_correctness =
+  test
+    (if expect_correctness then name else name ^ ".should-have-diff")
+    begin fun () ->
+
+    skip_if (not @@ expect_correctness) "No pre-emptive threads";
+
+    let cflags =
+      "-thread -package threads.posix " ^ (with_bisect_args bisect) in
+
+    let cflags =
+      if not with_threads then cflags
+      else cflags ^ " " ^ (with_bisect_thread ())
+    in
+
+    compile cflags "thread-safety/source.ml";
+    run command;
+    report "-xml -" ~r:"| grep -v element | grep 'for' > output";
+
+    if expect_correctness then
+      diff "thread-safety/reference"
+    else
+      run "! diff ../thread-safety/reference output > /dev/null 2> /dev/null"
+  end
+
+let tests = "thread-safety" >::: [
+  test "safe"           ~bisect:"-mode safe"                      false;
+  test "safe-threads"   ~bisect:"-mode safe" ~with_threads:true   true;
+  test "fast"           ~bisect:"-mode fast"                      false;
+  test "fast-threads"   ~bisect:"-mode fast" ~with_threads:true   true;
+  test "faster"         ~bisect:"-mode faster"                    false;
+  test "faster-threads" ~bisect:"-mode faster" ~with_threads:true false
+]


### PR DESCRIPTION
Part of #41.

The tester itself "should" be done, but I'm having trouble producing a program in which one thread actually pre-empts another during counting. @rleonid can you take a look at the `source.ml`?

Both threads are indeed running. The tester expects the count to be wrong here (not 2 million), but it comes to 2 million anyway. I don't know if it's the `Threads` implementation on my system, bad code on my part, or it's just that rare for pre-emption to happen there in that loop.

I inspected the output of `bisect_ppx` with `-dsource`, and it indeed doesn't take locks.