### PR TITLE
More build system and metadata cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,13 @@
-*.annot
-*.cmo
-*.cma
-*.cmi
-*.cmp
-*.a
-*.o
-*.cmx
-*.cmxs
-*.cmxa
-
-# ocamlbuild working directory
+# working and output directories
 _build/
+ocamldoc/
 
-# ocamlbuild targets
-*.byte
-*.native
-
-# test results
+# test working directory
 tests/_scratch
 
-# targets
-bisect-report
-bisect-report.opt
+# generated module lists
 bisect.mlpack
 bisect.odocl
+
+# scratch directory for notes, etc.
+scratch/

--- a/META
+++ b/META
@@ -2,7 +2,7 @@ description="code coverage tool via ppx"
 requires="bisect_ppx.runtime"
 version="0.2.6"
 
-ppx = "./bisect_ppx.byte"
+ppx="./bisect_ppx.byte"
 
 package "runtime" (
   version="0.2.6"
@@ -19,6 +19,7 @@ package "runtime" (
 package "fast" (
   requires="bisect_ppx.runtime"
   ppx="./bisect_ppx.byte"
-  ppxopt = "bisect_ppx.fast,-mode bisect_ppx.fast,fast"
+  ppxopt="bisect_ppx.fast,-mode bisect_ppx.fast,fast"
   description="The Bisect modules needed for instrumentation, running in fast mode."
+  version="0.2.6"
 )

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tests: FORCE
 
 clean: FORCE
 	ocamlbuild -clean
-	cd tests && make $(MAKE_QUIET) clean
+	make $(MAKE_QUIET) -C tests clean
 
 distclean: clean
 	rm -rf ocamldoc
@@ -59,7 +59,6 @@ distclean: clean
 install: FORCE
 	ocamlfind query $(INSTALL_NAME) && ocamlfind remove $(INSTALL_NAME) || true; \
 	ocamlfind install $(INSTALL_NAME) META -optional \
-		_build/bisect_ppx.cmo \
 		_build/src/threads/bisectThread.cm* \
 		_build/src/threads/bisectThread.o \
 		_build/src/syntax/bisect_ppx.byte \

--- a/opam/opam
+++ b/opam/opam
@@ -16,3 +16,4 @@ depends: [
   "ocamlbuild" {build}
   "ounit" {test}
 ]
+available: ocaml-version >= "4.02.0"


### PR DESCRIPTION
- Cleaned up `.gitignore`.
- Cleaned up `META` and added version number to `fast` subpackage. It looked weird without it in `ocamlfind list`.
- Put a compiler constraint in `opam`, so that in the extremely unlikely event we drop ppx_tools, or ppx_tools supports 4.01.0, Bisect_ppx does not become installable (yet broken).