### PR TITLE
Use Bisect_ppx on Bisect_ppx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,16 @@
 # working and output directories
 _build/
+_build.*/
+_install.meta/
 ocamldoc/
 
-# test working directory
+# test working and coverage directories
 tests/_scratch
+tests/_coverage
+tests/_report
 
 # generated module lists
-bisect.mlpack
+*.mlpack
 bisect.odocl
 
 # scratch directory for notes, etc.

--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,12 @@
 
 # DEFINITIONS
 
-INSTALL_NAME=bisect_ppx
-MODULES_ODOCL=bisect.odocl
-MODULES_MLPACK=bisect.mlpack
+INSTALL_NAME := bisect_ppx
+MODULES_ODOCL := bisect.odocl
+MODULES_MLPACK := bisect.mlpack
 
 # Assume that ocamlbuild, ocamlfind, ocamlopt are found in path.
-OCAMLBUILD_FLAGS=-use-ocamlfind -no-links -cflag -annot
-MAKE_QUIET=--no-print-directory
-
-# TARGETS
+OCAMLBUILD_FLAGS := -use-ocamlfind -no-links -cflag -annot
 
 default:
 	@echo "available targets:"
@@ -41,23 +38,23 @@ all:
 	ocamlbuild $(OCAMLBUILD_FLAGS) bisect.otarget
 
 doc: FORCE
-	ocamlbuild $(OCAMLBUILD_FLAGS) bisect.docdir/index.html && \
-	mkdir -p ocamldoc && \
+	ocamlbuild $(OCAMLBUILD_FLAGS) bisect.docdir/index.html
+	mkdir -p ocamldoc
 	cp _build/bisect.docdir/*.html _build/bisect.docdir/*.css ocamldoc
 
 tests: FORCE
-	make $(MAKE_QUIET) -C tests unit
+	make -C tests unit
 
 clean: FORCE
 	ocamlbuild -clean
-	make $(MAKE_QUIET) -C tests clean
+	make -C tests clean
 
 distclean: clean
 	rm -rf ocamldoc
 	rm -f $(MODULES_ODOCL) $(MODULES_MLPACK)
 
 install: FORCE
-	ocamlfind query $(INSTALL_NAME) && ocamlfind remove $(INSTALL_NAME) || true; \
+	! ocamlfind query $(INSTALL_NAME) || ocamlfind remove $(INSTALL_NAME)
 	ocamlfind install $(INSTALL_NAME) META -optional \
 		_build/src/syntax/bisect_ppx.byte \
 		_build/bisect.a \

--- a/_tags
+++ b/_tags
@@ -21,7 +21,8 @@ true: -traverse, warn_error(Ae)
 <src/**>: include
 
 # Options
-<src/**>: use_unix, for-pack(Bisect)
+<src/**>: use_unix
+<src/library/*>: runtime
 "src/syntax/instrumentPpx.ml": package(ppx_tools)
 "src/syntax/instrumentPpx.mli": package(ppx_tools)
 "src/syntax/bisect_ppx.ml": package(ppx_tools)
@@ -30,3 +31,7 @@ true: -traverse, warn_error(Ae)
 
 # Generation of version file
 "src/library/version.mli": src_library_version_ml
+
+# Self-instrumentation for testing and showing off
+<src/**>: instrument
+"src/library/extension.mli": src_library_extension_ml

--- a/meta_bisect.itarget
+++ b/meta_bisect.itarget
@@ -1,0 +1,5 @@
+meta_bisect.cma
+meta_bisect.cmxa
+src/syntax/bisect_ppx.byte
+src/report/report.byte
+src/report/report.native

--- a/opam/opam
+++ b/opam/opam
@@ -6,7 +6,7 @@ authors: "Leonid Rozenberg <leonidr@gmail.com>"
 homepage: "https://github.com/rleonid/bisect_ppx"
 bug-reports: "https://github.com/rleonid/bisect_ppx/issues"
 dev-repo: "https://github.com/rleonid/bisect_ppx.git"
-build: [make "all"]
+build: [make "build"]
 build-test: [make "tests"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "bisect_ppx"]

--- a/src/library/extension.mli
+++ b/src/library/extension.mli
@@ -1,6 +1,6 @@
 (*
- * This file is part of Bisect.
- * Copyright (C) 2008-2012 Xavier Clerc.
+ * This file is part of Bisect_ppx.
+ * Copyright (C) 2016 Anton Bachin.
  *
  * Bisect is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,15 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *)
 
-(** This module defines the values related to command-line analysis. *)
+(** Bisect output files extension. *)
 
-
-val kinds : (Common.point_kind * (bool ref)) list
-(** Association list mapping points kinds to whether they are activated. *)
-
-val runtime_name : string ref
-(** Runtime module name. Defaults to [Bisect], but should be set to
-    [Meta_bisect] when applying Bisect_ppx to itself. *)
-
-val switches : (Arg.key * Arg.spec * Arg.doc) list
-(** Command-line switches. *)
+val value : string
+(** Output file extension. This is [out], except when built as [Meta_bisect] for
+    self-instrumentation. Then, it is [out.meta]. *)

--- a/src/library/runtime.ml
+++ b/src/library/runtime.ml
@@ -62,7 +62,7 @@ let file_channel () =
   let suffix = ref 0 in
   let next_name () =
     incr suffix;
-    Printf.sprintf "%s%04d.out" base_name !suffix
+    Printf.sprintf "%s%04d.%s" base_name !suffix Extension.value
   in
   let rec ic_opt_loop actual_name =
     try

--- a/src/syntax/instrumentArgs.ml
+++ b/src/syntax/instrumentArgs.ml
@@ -28,6 +28,8 @@ let set_kinds v s =
       with _ -> raise (Arg.Bad (Printf.sprintf "unknown point kind: %C" ch)))
     s
 
+let runtime_name = ref "Bisect"
+
 let desc_kinds =
   let lines =
     List.map
@@ -58,5 +60,9 @@ let switches = [
   ("-mode",
    (Arg.Symbol (["safe"; "fast"; "faster"], ignore)),
    "  Ignored") ;
+
+  ("-runtime",
+   Arg.String ((:=) runtime_name),
+   "  Set runtime module name; used for testing")
 
 ]

--- a/src/syntax/instrumentPpx.ml
+++ b/src/syntax/instrumentPpx.ml
@@ -153,7 +153,8 @@ let faster file =
   let nb = List.length (InstrumentState.get_points_for_file file) in
   let ilid s = Exp.ident (lid s) in
   let init =
-    apply_nolabs (lid "Bisect.Runtime.init_with_array")
+    apply_nolabs
+      (lid ((!InstrumentArgs.runtime_name) ^ ".Runtime.init_with_array"))
       [strconst file; ilid "marks"]
   in
   let make = apply_nolabs (lid "Array.make") [intconst nb; intconst 0] in

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,6 +24,12 @@ PERFORMANCE := \
 	ocamlbuild $(OCAMLBUILD_FLAGS) performance/test_performance.native -- \
 		-runner sequential -display false
 
+COVERAGE := _coverage
+REPORT := \
+	../_build.meta/src/report/report.byte -I ../_build.instrumented \
+	$(COVERAGE)/*.out
+REPORT_DIR := _report
+
 default: FORCE
 	@echo 'Available targets:'
 	@echo '  unit             runs unit tests'
@@ -32,10 +38,14 @@ default: FORCE
 	@echo '  log              show log for last unit test execution'
 	@echo '  performance      runs the performance tests'
 	@echo '  all              runs all tests'
+	@echo '  coverage         generate HTML coverage report'
 	@echo '  clean            deletes build and log files'
 
 unit: binaries-may-exist
-	$(UNIT)
+	@rm -rf $(COVERAGE)
+	@$(UNIT)
+	@echo " Coverage:"
+	@$(REPORT) -summary-only -text - | grep --color=none total
 
 one: binaries-may-exist
 	$(UNIT) -only-test $(NAME)
@@ -51,12 +61,17 @@ performance: binaries-may-exist
 
 all: unit performance
 
+coverage: FORCE
+	test -d $(COVERAGE) || make unit
+	$(REPORT) -html $(REPORT_DIR)
+	@echo "\nSee _report/index.html"
+
 clean: FORCE
 	ocamlbuild -clean
-	rm -rf _scratch
+	rm -rf _scratch $(COVERAGE) $(REPORT_DIR)
 
 binaries-may-exist:
-	@test -d ../_build || \
-		( echo "Run' make all' in the project root directory"; false )
+	@test -d ../_build.instrumented || \
+		( echo "Run' make dev' in the project root directory"; false )
 
 FORCE:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,11 @@
 Running tests
 -------------
 
-To run all unit tests, run `make tests` in the project directory, or `make unit`
-in subdirectory `tests/`.
+To run all unit tests, run `make tests` in the project root directory, or
+`make unit` in subdirectory `tests/`. You must have first done `make dev` in the
+project root directory. At the end of testing, you will get a summary coverage
+report courtesy of Bisect_ppx itself. If you want a more detailed view, run
+`make coverage` and view `tests/_report/index.html`.
 
 If a test fails, you will see an error message describing the problem. If you
 want to re-run only that test, you can do `make one NAME=test_name` in `tests/`.

--- a/tools/travis_ci_test.sh
+++ b/tools/travis_ci_test.sh
@@ -55,11 +55,12 @@ opam install ocamlfind ocamlbuild ppx_tools
 echo
 echo "Compiling"
 echo
-make all
+make build
 
 opam install ounit ppx_blob ppx_deriving # Used in test suite.
 echo
 echo "Testing"
 echo
+make dev
 make tests STRICT_DEPENDENCIES=yes
 ( cd tests && make performance )


### PR DESCRIPTION
See the commit message.

This generates reports like

```
Finished, 41 targets (0 cached) in 00:00:02.
......................................................SSSSSS..SS....
Ran: 68 tests in: 14.41 seconds.
OK: Cases: 68 Skip: 8
 Coverage:
 - total: 1197/1598 (74.91%)
```

![screen shot 2016-01-19 at 19 51 57](https://cloud.githubusercontent.com/assets/12073668/12437790/8f548d48-bee6-11e5-8d1c-99309b599f32.png)

We can improve the HTML and put this into Coveralls later.

This PR should be based on the "one mode" PR #50, because it makes this one much easier to develop, but I based it on master for the future. Please disregard the first few commits that are also in #50.