### PR TITLE
Improve HTML legibility

### DIFF
--- a/src/report/reportHTML.ml
+++ b/src/report/reportHTML.ml
@@ -52,10 +52,17 @@ let css =  [
   "    width: 75%;" ;
   "}" ;
   "" ;
-  ".lineNone { white-space: nowrap; background: white; font-family: monospace; }" ;
-  ".lineAllVisited { white-space: nowrap; background: #30FF6A; font-family: monospace; }" ;
-  ".lineAllUnvisited { white-space: nowrap; background: #FF4423; font-family: monospace; }" ;
-  ".lineMixed { white-space: nowrap; background: #E4FF5B; font-family: monospace; }" ;
+  ".lineNone { white-space: nowrap; background: white; }" ;
+  ".lineAllVisited { white-space: nowrap; background: #AAFFC2; }" ;
+  ".lineAllUnvisited { white-space: nowrap; background: #FFCAC0; }" ;
+  ".lineMixed { white-space: nowrap; background: #F4FFBE; }" ;
+  "" ;
+  ".lineNone, .lineAllVisited, .lineAllUnvisited, .lineMixed {" ;
+  "    font-family: Consolas, \"Liberation Mono\", Menlo, Courier, monospace;" ;
+  "    font-size: 12px;" ;
+  "    line-height: 1.45;" ;
+  "}" ;
+  "" ;
   "" ;
   "table.simple {" ;
   "    border-width: 1px;" ;
@@ -98,8 +105,8 @@ let css =  [
   "    border-collapse: collapse;" ;
   "}" ;
   "" ;
-  ".gaugeOK { background: green; }" ;
-  ".gaugeKO { background: red; }" ;
+  ".gaugeOK { background: #61B961; }" ;
+  ".gaugeKO { background: #FF5757; }" ;
   ".gaugeNO { background: gray; }" ;
   ""
 ]


### PR DESCRIPTION
- Fonts with clearer characters (font stack, size, line height taken from GitHub, presumably they know what they are doing for each system).
- Desaturated background colors so black text remains visible over them.

Here are some before/afters.

Colors before:

![screen shot 2016-01-20 at 00 01 23](https://cloud.githubusercontent.com/assets/12073668/12441198/2c88bc88-bf0a-11e5-828b-dc4262d441b8.png)

Can barely read black text on red when tired. After:

![screen shot 2016-01-19 at 23 56 36](https://cloud.githubusercontent.com/assets/12073668/12441205/3a6c35a0-bf0a-11e5-8192-f4bcd169b960.png)

Font before:

![screen shot 2016-01-20 at 00 04 05](https://cloud.githubusercontent.com/assets/12073668/12441211/473da11a-bf0a-11e5-92a3-b00d8bd67aed.png)

The tildes (in `~loc`) really look a lot like minuses when tired. After:

![screen shot 2016-01-20 at 00 05 12](https://cloud.githubusercontent.com/assets/12073668/12441217/5b944222-bf0a-11e5-93df-a7da58784925.png)

Now clear. Don't know what this looks like on Windows or Linux, but guessing the fonts on those systems are clearer as well.