### PR TITLE
Support writing to STDOUT for -bisect output

### DIFF
--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -91,16 +91,16 @@ let main () =
     | ReportArgs.Dump_output file ->
         generic_output file (ReportDump.make ())
     | ReportArgs.Bisect_output file ->
-        Common.try_out_channel
-          true
-          file
-          (fun chan ->
-            let data =
-              Hashtbl.fold
-                (fun k v acc -> (k, v) :: acc)
-                data
-                [] in
-            Common.write_runtime_data chan data) in
+      let write chan =
+        let data =
+          Hashtbl.fold
+            (fun k v acc -> (k, v) :: acc)
+            data
+            [] in
+        Common.write_runtime_data chan data in
+      match file with
+      | "-" -> set_binary_mode_out stdout true; write stdout
+      | _ -> Common.try_out_channel true file write in
   List.iter write_output (List.rev !ReportArgs.outputs)
 
 let () =


### PR DESCRIPTION
Tested by temporarily changing report `-bisect` test case to take output from `STDOUT`. No permanent test included.

Fixes #33.