### PR TITLE
Suppress warning 27 in or-expanded instrument

### DIFF
--- a/src/syntax/instrumentPpx.ml
+++ b/src/syntax/instrumentPpx.ml
@@ -277,7 +277,7 @@ let wrap_case k case =
          never be exhaustive. *)
       let marks_expr =
         Exp.attr marks_expr
-          (Location.mkloc "ocaml.warning" loc, PStr [Str.eval (strconst "-8-11")])
+          (Location.mkloc "ocaml.warning" loc, PStr [Str.eval (strconst "-8-11-27")])
       in
 
       Exp.case (reassemble wrapped_pattern) ?guard:maybe_guard

--- a/tests/instrument/expr_match.ml.reference
+++ b/tests/instrument/expr_match.ml.reference
@@ -107,7 +107,7 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | Foo  -> (___bisect_mark___expr_match 42; ())
            | Bar  -> (___bisect_mark___expr_match 43; ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "foo"))
 let f x =
   ___bisect_mark___expr_match 47;
@@ -116,7 +116,7 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | (Foo ,_) -> (___bisect_mark___expr_match 45; ())
            | (Bar ,_) -> (___bisect_mark___expr_match 46; ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "foo"))
 let f x =
   ___bisect_mark___expr_match 52;
@@ -139,7 +139,7 @@ let f x =
                (___bisect_mark___expr_match 50;
                 ___bisect_mark___expr_match 51;
                 ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "foo"))
 let f x =
   ___bisect_mark___expr_match 55;
@@ -168,7 +168,7 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | Foo  as y -> (___bisect_mark___expr_match 63; ())
            | Bar  as y -> (___bisect_mark___expr_match 64; ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         y))
 let f x =
   ___bisect_mark___expr_match 70;
@@ -183,7 +183,7 @@ let f x =
                (___bisect_mark___expr_match 68;
                 ___bisect_mark___expr_match 66;
                 ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "foo")
    | [] -> (___bisect_mark___expr_match 69; print_endline "bar"))
 let f x =
@@ -194,7 +194,7 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | `B (Foo ) -> (___bisect_mark___expr_match 72; ())
            | `B (Bar ) -> (___bisect_mark___expr_match 73; ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "bar"))
 type v = {
   a: t;
@@ -220,7 +220,7 @@ let f x =
                (___bisect_mark___expr_match 77;
                 ___bisect_mark___expr_match 78;
                 ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "foo"))
 let f x =
   ___bisect_mark___expr_match 87;
@@ -248,7 +248,7 @@ let f x =
                 ___bisect_mark___expr_match 85;
                 ___bisect_mark___expr_match 81;
                 ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "bar")
    | _ -> (___bisect_mark___expr_match 86; print_newline ()))
 let f x =
@@ -258,7 +258,7 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | (lazy Foo ) -> (___bisect_mark___expr_match 88; ())
            | (lazy Bar ) -> (___bisect_mark___expr_match 89; ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "foo"))
 exception Exn of t
 let f x =
@@ -268,6 +268,6 @@ let f x =
        ((((match ___bisect_matched_value___ with
            | Exn (Foo ) -> (___bisect_mark___expr_match 91; ())
            | Exn (Bar ) -> (___bisect_mark___expr_match 92; ())
-           | _ -> ()))[@ocaml.warning "-8-11"]);
+           | _ -> ()))[@ocaml.warning "-8-11-27"]);
         print_endline "foo")
    | _ -> (___bisect_mark___expr_match 93; print_endline "bar"))


### PR DESCRIPTION
The instrumented code was failing because this
```OCaml
  match bisection_explicit ~epsilon ~lower ~upper f with
  | `EqZero v 
  | `CloseEnough v -> v
  | `Outside _     ->
```
was getting expanded to
```OCaml
   | `EqZero v|`CloseEnough v as ___bisect_matched_value___ ->
       ((((match ___bisect_matched_value___ with
           | `EqZero v -> (___bisect_mark___src/lib/solvers 64; ())
           | `CloseEnough v -> (___bisect_mark___src/lib/solvers 65; ())
           | _ -> ()))[@ocaml.warning "-8-11"]);
        v)
``` 
and the `v` in the inner match is unused.  This seems easier than trying to do something like `v` -> `_v` robustly.