### PR TITLE
Ocamlbuild plugin helper module

### DIFF
--- a/_tags
+++ b/_tags
@@ -21,13 +21,14 @@ true: -traverse, warn_error(Ae)
 <src/**>: include
 
 # Options
-<src/*/*/**>: use_unix
+<src/*/*.{byte,native}>: use_unix
 <src/library/*>: runtime
 "src/syntax/instrumentPpx.ml": package(ppx_tools)
 "src/syntax/instrumentPpx.mli": package(ppx_tools)
 "src/syntax/bisect_ppx.ml": package(ppx_tools)
-<src/syntax/bisect_ppx.{byte,native,jar}>: use_str, package(ppx_tools)
-<src/report/report.{byte,native,jar}>: use_str
+<src/syntax/bisect_ppx.{byte,native}>: use_str, package(ppx_tools)
+<src/report/report.{byte,native}>: use_str
+<src/ocamlbuild/*>: package(ocamlbuild)
 
 # Self-instrumentation for testing and showing off
 <src/*/*/**>: instrument

--- a/src/META
+++ b/src/META
@@ -15,3 +15,10 @@ package "fast" (
   description="Code coverage for OCaml (deprecated package)"
   requires="bisect_ppx"
 )
+
+package "plugin" (
+  version="0.2.6"
+  description="Bisect_ppx Ocamlbuild plugin"
+  archive(byte)="bisect_ppx_plugin.cma"
+  archive(native)="bisect_ppx_plugin.cmxa"
+)

--- a/src/ocamlbuild/bisect_ppx_plugin.ml
+++ b/src/ocamlbuild/bisect_ppx_plugin.ml
@@ -1,0 +1,35 @@
+(*
+ * This file is part of Bisect_ppx.
+ * Copyright (C) 2016 Anton Bachin.
+ *
+ * Bisect is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *)
+
+open Ocamlbuild_plugin
+
+let _tag_name = "coverage"
+let _environment_variable = "BISECT_COVERAGE"
+let _enable = "YES"
+
+let handle_coverage () =
+  if getenv ~default:"" _environment_variable <> _enable then
+    mark_tag_used _tag_name
+  else begin
+    flag ["ocaml"; "compile"; _tag_name] (S [A "-package"; A "bisect_ppx"]);
+    flag ["ocaml"; "link"; _tag_name] (S [A "-package"; A "bisect_ppx"])
+  end
+
+let dispatch = function
+  | After_rules -> handle_coverage ()
+  | _ -> ()

--- a/src/ocamlbuild/bisect_ppx_plugin.mli
+++ b/src/ocamlbuild/bisect_ppx_plugin.mli
@@ -1,0 +1,24 @@
+(*
+ * This file is part of Bisect_ppx.
+ * Copyright (C) 2016 Anton Bachin.
+ *
+ * Bisect is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *)
+
+val handle_coverage : unit -> unit
+(** Sets up handling for the [coverage] tag. *)
+
+val dispatch : Ocamlbuild_plugin.hook -> unit
+(** A helper that can be passed directly to [Ocamlbuild_plugin.dispatch]. Calls
+    [handle_coverage]. *)

--- a/src/travis_ci_test.sh
+++ b/src/travis_ci_test.sh
@@ -97,5 +97,12 @@ echo
 make clean
 opam pin add -yn .
 opam install -yt bisect_ppx
+opam remove -y bisect_ppx
+opam install -y bisect_ppx
 ocamlfind query bisect_ppx bisect_ppx.runtime bisect_ppx.fast
 which bisect-ppx-report
+
+echo
+echo "Testing package usage and Ocamlbuild plugin"
+echo
+make -C tests/usage

--- a/tests/_tags
+++ b/tests/_tags
@@ -1,2 +1,3 @@
 <*>: include
+"usage": -traverse, -include
 <**/test*>: package(oUnit)

--- a/tests/usage/.gitignore
+++ b/tests/usage/.gitignore
@@ -1,0 +1,2 @@
+bisect*.out
+_coverage/

--- a/tests/usage/Makefile
+++ b/tests/usage/Makefile
@@ -1,0 +1,36 @@
+#
+# This file is part of Bisect_ppx.
+# Copyright (C) 2016 Anton Bachin.
+#
+# Bisect is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bisect is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+OCAMLBUILD := \
+	ocamlbuild -use-ocamlfind -no-links -byte-plugin \
+	-plugin-tag 'package(bisect_ppx.plugin)'
+
+test: FORCE
+	make clean
+	$(OCAMLBUILD) source.byte --
+	! test -f bisect0001.out
+	BISECT_COVERAGE=YES $(OCAMLBUILD) source.byte --
+	test -f bisect0001.out
+	bisect-ppx-report -I _build/ -html _coverage/ bisect*.out
+	test -f _coverage/index.html
+
+clean: FORCE
+	$(OCAMLBUILD) -clean
+	rm -rf bisect*.out _coverage
+
+FORCE:

--- a/tests/usage/_tags
+++ b/tests/usage/_tags
@@ -1,0 +1,1 @@
+<*>: coverage

--- a/tests/usage/myocamlbuild.ml
+++ b/tests/usage/myocamlbuild.ml
@@ -1,0 +1,4 @@
+open Ocamlbuild_plugin
+
+let () =
+  dispatch Bisect_ppx_plugin.dispatch


### PR DESCRIPTION
Added a module for use in Ocamlbuild plugins, which should make it easy to

1. Decide which files should get instrumented (tag `coverage`).
2. Build those files both for testing (`BISECT_COVERAGE=YES`) and release (no instrumentation generated).

I will describe how to use the plugin in `advanced.md`, when discussing Ocamlbuild. With this plugin, it should only take a couple sentences.

Also added a usage test, which runs in Travis after Bisect_ppx is installed by OPAM. This test makes sure that the installed rewriter, runtime, reporter, and plugin module are all usable by third-party programs.

This pull request is currently based on #67, because #67 makes this one easier to develop. I will rebase this one when #67 request is in, in some form.