### PR TITLE
Set up GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ _build/
 _build.*/
 _findlib/
 ocamldoc/
+gh-pages/
 
 # test working and coverage directories
 tests/_scratch

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,23 @@ doc: FORCE
 	mkdir -p ocamldoc
 	cp _build/bisect.docdir/*.html _build/bisect.docdir/*.css ocamldoc
 
+GH_PAGES := gh-pages
+
+gh-pages: FORCE
+	ocamlbuild $(OCAMLBUILD_FLAGS) postprocess.byte
+	make -C tests coverage
+	rm -rf $(GH_PAGES)
+	mkdir -p $(GH_PAGES)
+	omd README.md | _build/doc/postprocess.byte > $(GH_PAGES)/index.html
+	cd $(GH_PAGES) && \
+		git init && \
+		git remote add github git@github.com:rleonid/bisect_ppx.git && \
+		mkdir -p coverage && \
+		cp -r ../tests/_report/* coverage/ && \
+		git add -A && \
+		git commit -m 'Bisect_ppx demonstration' && \
+		git push -uf github master:gh-pages
+
 tests: FORCE
 	make -C tests unit
 
@@ -119,7 +136,7 @@ clean: FORCE
 	ocamlbuild -clean
 	ocamlbuild $(META_BISECT_DIR) -clean
 	ocamlbuild $(INSTRUMENTED_DIR) -clean
-	rm -rf $(DEV_INSTALL_DIR) ocamldoc *.odocl src/*.mlpack
+	rm -rf $(DEV_INSTALL_DIR) ocamldoc *.odocl src/*.mlpack $(GH_PAGES)
 	make -C tests clean
 
 REWRITER := $(INSTALL_SOURCE_DIR)/bisect_ppx

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bisect_ppx &nbsp; [![version 0.2.6][version]][releases] [![Travis status][travis-img]][travis]
 
-Bisect_ppx is a code coverage tool for OCaml. It helps you test thoroughly by
-showing which parts of your code are **not** tested.
+[Bisect_ppx][self] is a code coverage tool for OCaml. It helps you test
+thoroughly by showing which parts of your code are **not** tested.
 
 ![Bisect_ppx usage example][sample]
 
@@ -10,6 +10,7 @@ showing which parts of your code are **not** tested.
 For a live demonstration, see the [coverage report][self-coverage] Bisect_ppx
 generates for itself.
 
+[self]:          https://github.com/rleonid/bisect_ppx
 [releases]:      https://github.com/rleonid/bisect_ppx/releases
 [version]:       https://img.shields.io/badge/version-0.2.6-blue.svg
 [self-coverage]: http://rleonid.github.io/bisect_ppx/coverage/

--- a/_tags
+++ b/_tags
@@ -33,3 +33,6 @@ true: -traverse, warn_error(Ae)
 # Self-instrumentation for testing and showing off
 <src/*/*/**>: instrument
 "src/library/extension.mli": src_library_extension_ml
+
+# Documentation
+<doc/**>: include, package(lambdasoup)

--- a/doc/postprocess.ml
+++ b/doc/postprocess.ml
@@ -1,0 +1,20 @@
+open Soup
+
+let () =
+  (* Read a template containing surrounding <html>, <head>, and <body> tags. *)
+  let soup = read_file "doc/template.html" |> parse in
+
+  (* Read OMD output from STDIN, and insert it into the template. *)
+  read_channel stdin
+  |> parse |> children |> iter (insert_before (soup $ "#css-attribution"));
+
+  (* OMD messes up the badge links in the header. Replace it. *)
+  create_element ~inner_text:"Bisect_ppx" "h1" |> replace (soup $ "h1");
+
+  (* OMD seems to interpret <br> tags as text, and turns them into
+     paragraphs. Fix that. *)
+  soup $$ "p:contains(\"&lt;br\")"
+  |> iter (fun e -> create_element "br" |> replace e);
+
+  (* Write the modified HTML to STDOUT. *)
+  soup |> to_string |> write_channel stdout

--- a/doc/template.html
+++ b/doc/template.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+
+<meta charset="utf-8">
+
+<title>Bisect_ppx</title>
+<meta name="description" content="Code coverage for OCaml.">
+<link rel="canonical" href="http://rleonid.github.io/bisect_ppx">
+
+<link rel="stylesheet" href="https://sindresorhus.com/github-markdown-css/github-markdown.css">
+
+<style>
+.markdown-body {
+    box-sizing: border-box;
+    min-width: 200px;
+    max-width: 980px;
+    margin: 0 auto;
+    padding: 45px;
+}
+
+#css-attribution {
+    margin-top: 5em;
+    opacity: 0.5;
+}
+</style>
+
+</head>
+<body class="markdown-body">
+
+<a href="https://github.com/rleonid/bisect_ppx"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/567c3a48d796e2fc06ea80409cc9dd82bf714434/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png"></a>
+
+<div id="css-attribution">
+  This page uses <a href="https://github.com/sindresorhus/github-markdown-css">github-markdown-css</a>.
+</div>
+
+</body>
+</html>

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -67,7 +67,7 @@ all: unit performance
 
 coverage: FORCE
 	test -d $(COVERAGE) || make unit
-	$(REPORT) -html $(REPORT_DIR)
+	$(REPORT) -html $(REPORT_DIR) -title "Coverage report for Bisect_ppx"
 	@echo "\nSee _report/index.html"
 
 clean: FORCE


### PR DESCRIPTION
This adds a `Makefile` target `gh-pages` for generating and publishing the GH Pages page for Bisect_ppx. See the [home page](http://rleonid.github.io/bisect_ppx/) and live [coverage report](http://rleonid.github.io/bisect_ppx/coverage/) – that's the entire site.

Doing this requires [OMD](https://github.com/ocaml/omd) and [Lambda Soup](https://github.com/aantron/lambda-soup). Since only repo collaborators can run this target, these aren't dependencies of Bisect_ppx.

@rleonid Can you please set the URL in the GitHub header to point to http://rleonid.github.io/bisect_ppx/coverage/? We could also point it to the home page, but that page seems redundant with `README.md`. Also, I think we should change the description to something like "Code coverage for OCaml."

I guess we could get fancy and postprocess every page in the live coverage report to point back to GitHub, among other modifications. What do you think about that? I think it's fine as is, but I'd be curious to hear opinions.