### PR TITLE
Add conflict with older ocveralls to opam

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -21,4 +21,7 @@ depends: [
   "ocamlbuild" {build}
   "ounit" {test}
 ]
+conflicts: [
+  "ocveralls" {<= "0.3.2"}
+]
 available: ocaml-version >= "4.02.0"


### PR DESCRIPTION
Test:

```
$ opam install ocveralls

=-=- Synchronising pinned packages =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫 
[ocveralls] ~/ocveralls updated
The following actions will be performed:
  ⊘  remove  bisect_ppx 0.2.6*                [conflicts with ocveralls]
  ∗  install bisect     1.3                   [required by ocveralls]
  ∗  install ocveralls  0.3.2*
===== ∗  2   ⊘  1 =====
```

Then, manually bumped ocveralls to 0.3.3 and it installs fine with Bisect_ppx.