### PR TITLE
Add projects that use Bisect_ppx

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ use it for tracing: run one test, and see what is visited.
 <br>
 
 For a live demonstration, see the [coverage report][self-coverage] Bisect_ppx
-generates for itself.
+generates for itself. You may also want to see
+[projects that use Bisect_ppx](#bisect_ppx-in-practice).
 
 [self]:          https://github.com/rleonid/bisect_ppx
 [releases]:      https://github.com/rleonid/bisect_ppx/releases
@@ -61,6 +62,25 @@ See also the [advanced usage][advanced].
 [ocamlbuild]: https://github.com/rleonid/bisect_ppx/blob/master/doc/advanced.md#Ocamlbuild
 [ocveralls]:  https://github.com/sagotch/ocveralls
 [advanced]:   https://github.com/rleonid/bisect_ppx/blob/master/doc/advanced.md
+
+
+
+<br>
+
+## Bisect_ppx in practice
+
+A small sample of projects using Bisect_ppx:
+
+- [Oml][oml]: [report][oml-coveralls]
+- [ctypes][ctypes]: [report][ctypes-coveralls]
+- [Markup.ml][markupml]: [report][markupml-coveralls]
+
+[oml]:                https://github.com/hammerlab/oml
+[oml-coveralls]:      https://coveralls.io/github/hammerlab/oml?branch=HEAD
+[ctypes]:             https://github.com/ocamllabs/ocaml-ctypes
+[ctypes-coveralls]:   https://coveralls.io/github/ocamllabs/ocaml-ctypes
+[markupml]:           https://github.com/aantron/markup.ml
+[markupml-coveralls]: https://coveralls.io/github/aantron/markup.ml?branch=master
 
 
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ A small sample of projects using Bisect_ppx:
 - [Oml][oml]: [report][oml-coveralls]
 - [ctypes][ctypes]: [report][ctypes-coveralls]
 - [Markup.ml][markupml]: [report][markupml-coveralls]
+- [Ketrew][ketrew]
+- [Sosa][sosa]
 
 [oml]:                https://github.com/hammerlab/oml
 [oml-coveralls]:      https://coveralls.io/github/hammerlab/oml?branch=HEAD
@@ -81,6 +83,8 @@ A small sample of projects using Bisect_ppx:
 [ctypes-coveralls]:   https://coveralls.io/github/ocamllabs/ocaml-ctypes
 [markupml]:           https://github.com/aantron/markup.ml
 [markupml-coveralls]: https://coveralls.io/github/aantron/markup.ml?branch=master
+[ketrew]:             https://github.com/hammerlab/ketrew
+[sosa]:               https://github.com/hammerlab/sosa
 
 
 


### PR DESCRIPTION
I did a GitHub search for Bisect_ppx. I tried to pick "well-known" projects, and took only those that post a coverage report that we can link to. However, I am not in a position to fairly state if Markup.ml qualifies as "well-known." Indeed, it's quite young and unproven. I can, however, say that it has a lot of code, and benefitted greatly from Bisect_ppx. It brought me here :)

In general, due to our involvement, I would prefer to list neither Oml nor Markup.ml in the project list, under such a subjective criterion. However, this would leave us with only one (or two, if we keep Oml) project in the list.

What do you think?